### PR TITLE
Add shrinking for `Alloc`

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -73,7 +73,7 @@ impl<T, A: Allocator> RawMem for Alloc<T, A> {
 
         #[allow(clippy::unit_arg)] // it is allows shortest return `Ok(())`
         Ok({
-            self.buf.set_ptr(ptr.cast());
+            self.buf.set_ptr(ptr);
         })
     }
 }

--- a/src/raw_place.rs
+++ b/src/raw_place.rs
@@ -78,8 +78,8 @@ impl<T> RawPlace<T> {
         self.len = cap;
     }
 
-    pub fn set_ptr(&mut self, ptr: NonNull<T>) {
-        self.ptr = ptr;
+    pub fn set_ptr(&mut self, ptr: NonNull<[u8]>) {
+        self.ptr = ptr.cast();
     }
 }
 


### PR DESCRIPTION
- `current_memory` is safe, because `len|cap` doesn't change by caller