### PR TITLE
Add some checks into `modern-api`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
-#![feature(allocator_api)]
-#![feature(unchecked_math)]
-#![feature(maybe_uninit_slice)]
-#![feature(slice_ptr_get)]
-#![feature(ptr_as_uninit)]
-//
+#![feature(
+    allocator_api,
+    unchecked_math,
+    maybe_uninit_slice,
+    slice_ptr_get,
+    ptr_as_uninit,
+    inline_const
+)]
 // special lint
 #![cfg_attr(not(test), forbid(clippy::unwrap_used))]
 // rust compiler lints


### PR DESCRIPTION
### It requested parallel with review
- sizeof is aligned as align
- temp zst forbid
- debug assertion to help use chain of `shrink_to` → `set_ptr`
- best debug message – `..` usually knowns as `Range<Of>`