### PR TITLE
`Deref` Initiative

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -8,6 +8,7 @@ use {
         alloc::{Allocator, Layout},
         fmt::{self, Debug, Formatter},
         mem::{self, MaybeUninit},
+        ops::{Deref, DerefMut},
         ptr,
     },
 };
@@ -23,16 +24,22 @@ impl<T, A: Allocator> Alloc<T, A> {
     }
 }
 
-impl<T, A: Allocator> RawMem for Alloc<T, A> {
-    type Item = T;
+impl<T, A: Allocator> Deref for Alloc<T, A> {
+    type Target = [T];
 
-    fn allocated(&self) -> &[Self::Item] {
+    fn deref(&self) -> &Self::Target {
         unsafe { self.buf.as_slice() }
     }
+}
 
-    fn allocated_mut(&mut self) -> &mut [Self::Item] {
+impl<T, A: Allocator> DerefMut for Alloc<T, A> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { self.buf.as_slice_mut() }
     }
+}
+
+impl<T, A: Allocator> RawMem for Alloc<T, A> {
+    type Item = T;
 
     unsafe fn grow(
         &mut self,

--- a/src/file_mapped.rs
+++ b/src/file_mapped.rs
@@ -7,6 +7,7 @@ use {
         fs::File,
         io,
         mem::{self, MaybeUninit},
+        ops::{Deref, DerefMut},
         path::Path,
         ptr::{self, NonNull},
     },
@@ -42,16 +43,22 @@ impl<T> FileMapped<T> {
     }
 }
 
-impl<T> RawMem for FileMapped<T> {
-    type Item = T;
+impl<T> Deref for FileMapped<T> {
+    type Target = [T];
 
-    fn allocated(&self) -> &[Self::Item] {
+    fn deref(&self) -> &Self::Target {
         unsafe { self.buf.as_slice() }
     }
+}
 
-    fn allocated_mut(&mut self) -> &mut [Self::Item] {
+impl<T> DerefMut for FileMapped<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         unsafe { self.buf.as_slice_mut() }
     }
+}
+
+impl<T> RawMem for FileMapped<T> {
+    type Item = T;
 
     unsafe fn grow(
         &mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,18 +45,25 @@ macro_rules! delegate_memory {
             use std::{
                 mem::MaybeUninit,
                 fmt::{self, Formatter},
+                ops::{Deref, DerefMut},
             };
+
+            impl<$param> Deref for $me<$param> {
+                type Target = [$param];
+
+                fn deref(&self) -> &Self::Target {
+                    &*self.0
+                }
+            }
+
+            impl<$param> DerefMut for$me<$param> {
+                fn deref_mut(&mut self) -> &mut Self::Target {
+                    &mut *self.0
+                }
+            }
 
             impl<$param> RawMem for $me<$param> {
                 type Item = $param;
-
-                fn allocated(&self) -> &[Self::Item] {
-                    self.0.allocated()
-                }
-
-                fn allocated_mut(&mut self) -> &mut [Self::Item] {
-                    self.0.allocated_mut()
-                }
 
                 unsafe fn grow(
                     &mut self,
@@ -138,12 +145,12 @@ fn miri() {
         for _ in 0..10 {
             mem.grow_filled(GROW, val.clone())?;
         }
-        assert!(mem.allocated() == vec![val; GROW * 10]);
+        assert!(mem[..] == vec![val; GROW * 10]);
 
         for _ in 0..10 {
             mem.shrink(GROW)?;
         }
-        assert_eq!(mem.allocated().len(), 0);
+        assert_eq!(mem.len(), 0);
 
         Ok(())
     }

--- a/src/raw_mem.rs
+++ b/src/raw_mem.rs
@@ -1,6 +1,7 @@
 use std::{
     alloc::Layout,
     mem::{self, MaybeUninit},
+    ops::{Deref, DerefMut},
     ptr,
 };
 
@@ -67,11 +68,8 @@ impl<T> Drop for Guard<'_, T> {
     }
 }
 
-pub trait RawMem {
+pub trait RawMem: Deref<Target = [Self::Item]> + DerefMut {
     type Item;
-
-    fn allocated(&self) -> &[Self::Item];
-    fn allocated_mut(&mut self) -> &mut [Self::Item];
 
     /// # Safety
     /// Caller must guarantee that `fill` makes the uninitialized part valid for


### PR DESCRIPTION
Replace current `allocated`/`allocated_mut` from `RawPlace`, to flexible `Deref` which, however, is more confusing.
What do you think about this?