### PR TITLE
fix: replace unsupported look-ahead regex in create-github-release.rs and add release badges

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-13T07:43:49.762Z for PR creation at branch issue-34-391429b63e61 for issue https://github.com/linksplatform/mem-rs/issues/34

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-13T07:43:49.762Z for PR creation at branch issue-34-391429b63e61 for issue https://github.com/linksplatform/mem-rs/issues/34

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -435,7 +435,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "platform-mem"
-version = "0.1.0-pre+beta.2"
+version = "0.2.0"
 dependencies = [
  "allocator-api2",
  "criterion",

--- a/changelog.d/20260413-fix-github-release.md
+++ b/changelog.d/20260413-fix-github-release.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+---
+### Fixed
+- Fixed GitHub Release creation failure caused by unsupported look-ahead regex in `create-github-release.rs` (Rust's `regex` crate does not support look-around assertions)
+- Added crates.io and docs.rs badges to GitHub Release notes, matching the template repository best practices

--- a/docs/case-studies/issue-34/analysis.md
+++ b/docs/case-studies/issue-34/analysis.md
@@ -1,0 +1,82 @@
+# Case Study: Issue #34 - No GitHub Release Was Published with Badge in Rust CI/CD
+
+## Timeline of Events
+
+1. **2026-04-13 07:18**: PR #33 merged to main (from branch `issue-32-bb6017cd91ca`), which replaced Node.js CI/CD scripts with Rust scripts and added crates.io publishing support.
+2. **2026-04-13 07:22**: CI/CD Pipeline triggered on push to main (SHA `ee9107a`).
+3. **2026-04-13 07:27**: Auto Release job ran successfully through version bumping, changelog collection, and crates.io publishing (`platform-mem@0.2.0` published successfully).
+4. **2026-04-13 07:27:44**: `create-github-release.rs` script panicked at line 48 with regex parse error: `look-around, including look-ahead and look-behind, is not supported`.
+5. **Result**: Crate v0.2.0 was published to crates.io, but no GitHub Release was created. The existing release `v0.1.0-pre+beta.2` remained as the only GitHub Release.
+
+## Requirements from the Issue
+
+| # | Requirement | Status |
+|---|-------------|--------|
+| 1 | Support automatic GitHub Release publishing | Fixed: Replaced look-ahead regex with compatible pattern |
+| 2 | Include badges in GitHub Releases | Fixed: Added crates.io and docs.rs badge generation |
+| 3 | Follow best practices from `trees-rs`, `Numbers`, and the template repo | Fixed: Script now matches template's badge feature |
+| 4 | Compile data to `docs/case-studies/issue-34/` folder | This document |
+| 5 | Report issues to other repos if relevant | Reported to `link-foundation/rust-ai-driven-development-pipeline-template` |
+
+## Root Cause Analysis
+
+### Root Cause: Unsupported Look-Ahead Regex in Rust's `regex` Crate
+
+**The failing code** (line 47-48 of `create-github-release.rs`):
+```rust
+let pattern = format!(r"(?s)## \[{}\].*?\n(.*?)(?=\n## \[|$)", escaped_version);
+let re = Regex::new(&pattern).unwrap();
+```
+
+The pattern `(?=\n## \[|$)` uses a **positive look-ahead assertion**, which is not supported by Rust's `regex` crate (it uses a finite automaton engine that guarantees linear-time matching, which is incompatible with look-around assertions).
+
+This bug was inherited from the template repository (`link-foundation/rust-ai-driven-development-pipeline-template`), where the same pattern exists in `scripts/create-github-release.rs`. The bug went undetected until a version with multiple changelog sections was processed (v0.2.0 had content before the `## [0.1.0]` section header, triggering the regex to attempt matching).
+
+### Contributing Factor: Missing Badges Feature
+
+The `create-github-release.rs` script in mem-rs was missing the automatic badge generation present in the template repository. The template includes crates.io and docs.rs badges in release notes, which were stripped during a previous simplification.
+
+## Solution
+
+### Fix 1: Replace Look-Ahead Regex with Compatible Pattern
+
+Instead of using `(?=\n## \[|$)` to find the boundary between changelog sections, the fix:
+1. Finds the version header using `(?m)^## \[{version}\]`
+2. Skips to the first newline after the header
+3. Uses a separate regex `(?m)^## \[` to find the start of the next section
+4. Takes the content between the two positions
+
+This approach achieves the same result without look-ahead, using only features supported by Rust's `regex` crate.
+
+### Fix 2: Restore Badge Generation
+
+Added back the badge generation from the template:
+- `get_rust_root()` — detects Cargo.toml location
+- `get_cargo_toml_path()` — constructs path to Cargo.toml
+- `get_crate_name_from_toml()` — extracts crate name
+- Badge format: `[![Crates.io](badge-url)](crate-url) [![Docs.rs](badge-url)](docs-url)`
+
+## Cross-Repository Issues
+
+The same regex bug exists in the template repository at `link-foundation/rust-ai-driven-development-pipeline-template`. An issue was filed there to fix the look-ahead regex in `create-github-release.rs`.
+
+## CI Log Evidence
+
+```
+Auto Release  Create GitHub Release  2026-04-13T07:27:44.0504016Z
+Auto Release  Create GitHub Release  2026-04-13T07:27:44.0505018Z thread 'main' (5683) panicked at scripts/create-github-release.rs:48:35:
+Auto Release  Create GitHub Release  2026-04-13T07:27:44.0511843Z called `Result::unwrap()` on an `Err` value: Syntax(
+Auto Release  Create GitHub Release  2026-04-13T07:27:44.0512240Z ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Auto Release  Create GitHub Release  2026-04-13T07:27:44.0512565Z regex parse error:
+Auto Release  Create GitHub Release  2026-04-13T07:27:44.0512795Z     (?s)## \[0\.2\.0\].*?\n(.*?)(?=\n## \[|$)
+Auto Release  Create GitHub Release  2026-04-13T07:27:44.0513040Z                                 ^^^
+Auto Release  Create GitHub Release  2026-04-13T07:27:44.0513387Z error: look-around, including look-ahead and look-behind, is not supported
+```
+
+## Verification
+
+The fix was verified with an experiment script (`experiments/test_changelog_regex.rs`) that tests:
+1. Extracting a version section with content after it (multi-section changelog)
+2. Extracting the last version section (no following section)
+3. Handling non-existent versions (fallback message)
+4. Single-section changelog edge case

--- a/experiments/test_changelog_regex.rs
+++ b/experiments/test_changelog_regex.rs
@@ -1,0 +1,88 @@
+#!/usr/bin/env rust-script
+//! Test that the changelog version extraction regex works correctly
+//! without using look-ahead (which Rust's regex crate doesn't support).
+//!
+//! ```cargo
+//! [dependencies]
+//! regex = "1"
+//! ```
+
+use regex::Regex;
+
+fn get_changelog_for_version(content: &str, version: &str) -> String {
+    let escaped_version = regex::escape(version);
+    let header_pattern = format!(r"(?m)^## \[{}\]", escaped_version);
+    let header_re = Regex::new(&header_pattern).unwrap();
+
+    if let Some(m) = header_re.find(content) {
+        let after_header = &content[m.end()..];
+        let body_start = after_header.find('\n').map_or(after_header.len(), |i| i + 1);
+        let body = &after_header[body_start..];
+
+        let next_section_re = Regex::new(r"(?m)^## \[").unwrap();
+        let section_body = if let Some(next) = next_section_re.find(body) {
+            &body[..next.start()]
+        } else {
+            body
+        };
+
+        let trimmed = section_body.trim();
+        if trimmed.is_empty() {
+            format!("Release v{}", version)
+        } else {
+            trimmed.to_string()
+        }
+    } else {
+        format!("Release v{}", version)
+    }
+}
+
+fn main() {
+    let changelog = r#"# Changelog
+
+## [0.2.0] - 2026-04-13
+
+### Changed
+- Migrated from Rust nightly to stable Rust
+
+### Fixed
+- Fixed clippy warnings
+
+## [0.1.0] - 2026-04-01
+
+### Added
+- Initial release
+"#;
+
+    // Test extracting v0.2.0
+    let result = get_changelog_for_version(changelog, "0.2.0");
+    assert!(result.contains("Migrated from Rust nightly"), "Should contain v0.2.0 content, got: {}", result);
+    assert!(result.contains("Fixed clippy warnings"), "Should contain v0.2.0 fixes, got: {}", result);
+    assert!(!result.contains("Initial release"), "Should NOT contain v0.1.0 content, got: {}", result);
+    println!("PASS: v0.2.0 extraction correct");
+
+    // Test extracting v0.1.0
+    let result = get_changelog_for_version(changelog, "0.1.0");
+    assert!(result.contains("Initial release"), "Should contain v0.1.0 content, got: {}", result);
+    assert!(!result.contains("Migrated"), "Should NOT contain v0.2.0 content, got: {}", result);
+    println!("PASS: v0.1.0 extraction correct");
+
+    // Test non-existent version
+    let result = get_changelog_for_version(changelog, "9.9.9");
+    assert_eq!(result, "Release v9.9.9");
+    println!("PASS: missing version returns default");
+
+    // Test single-section changelog (no next section)
+    let single = r#"# Changelog
+
+## [1.0.0] - 2026-01-01
+
+### Added
+- The only feature
+"#;
+    let result = get_changelog_for_version(single, "1.0.0");
+    assert!(result.contains("The only feature"), "Should extract from single section, got: {}", result);
+    println!("PASS: single section extraction correct");
+
+    println!("\nAll tests passed!");
+}

--- a/scripts/create-github-release.rs
+++ b/scripts/create-github-release.rs
@@ -1,6 +1,9 @@
 #!/usr/bin/env rust-script
 //! Create GitHub Release from CHANGELOG.md
 //!
+//! Automatically includes crates.io and docs.rs badges in release notes
+//! when the crate name can be detected from Cargo.toml.
+//!
 //! Usage: rust-script scripts/create-github-release.rs --release-version <version> --repository <repository>
 //!
 //! ```cargo
@@ -17,6 +20,36 @@ use std::path::Path;
 use std::process::{Command, Stdio, exit};
 use regex::Regex;
 use serde::Serialize;
+
+fn get_rust_root() -> String {
+    if let Some(root) = get_arg("rust-root") {
+        return root;
+    }
+
+    if Path::new("./Cargo.toml").exists() {
+        return ".".to_string();
+    }
+
+    if Path::new("./rust/Cargo.toml").exists() {
+        return "rust".to_string();
+    }
+
+    ".".to_string()
+}
+
+fn get_cargo_toml_path(rust_root: &str) -> String {
+    if rust_root == "." {
+        "./Cargo.toml".to_string()
+    } else {
+        format!("{}/Cargo.toml", rust_root)
+    }
+}
+
+fn get_crate_name_from_toml(cargo_toml_path: &str) -> Option<String> {
+    let content = fs::read_to_string(cargo_toml_path).ok()?;
+    let re = Regex::new(r#"(?m)^name\s*=\s*"([^"]+)""#).ok()?;
+    re.captures(&content).map(|c| c.get(1).unwrap().as_str().to_string())
+}
 
 fn get_arg(name: &str) -> Option<String> {
     let args: Vec<String> = env::args().collect();
@@ -42,13 +75,28 @@ fn get_changelog_for_version(version: &str) -> String {
         Err(_) => return format!("Release v{}", version),
     };
 
-    // Find the section for this version
     let escaped_version = regex::escape(version);
-    let pattern = format!(r"(?s)## \[{}\].*?\n(.*?)(?=\n## \[|$)", escaped_version);
-    let re = Regex::new(&pattern).unwrap();
+    let header_pattern = format!(r"(?m)^## \[{}\]", escaped_version);
+    let header_re = Regex::new(&header_pattern).unwrap();
 
-    if let Some(caps) = re.captures(&content) {
-        caps.get(1).unwrap().as_str().trim().to_string()
+    if let Some(m) = header_re.find(&content) {
+        let after_header = &content[m.end()..];
+        let body_start = after_header.find('\n').map_or(after_header.len(), |i| i + 1);
+        let body = &after_header[body_start..];
+
+        let next_section_re = Regex::new(r"(?m)^## \[").unwrap();
+        let section_body = if let Some(next) = next_section_re.find(body) {
+            &body[..next.start()]
+        } else {
+            body
+        };
+
+        let trimmed = section_body.trim();
+        if trimmed.is_empty() {
+            format!("Release v{}", version)
+        } else {
+            trimmed.to_string()
+        }
     } else {
         format!("Release v{}", version)
     }
@@ -88,7 +136,18 @@ fn main() {
 
     let mut release_notes = get_changelog_for_version(&version);
 
-    // Add crates.io link if provided
+    // Add crates.io and docs.rs badges
+    let rust_root = get_rust_root();
+    let cargo_toml = get_cargo_toml_path(&rust_root);
+    if let Some(crate_name) = get_crate_name_from_toml(&cargo_toml) {
+        let badges = format!(
+            "[![Crates.io](https://img.shields.io/crates/v/{}?label=crates.io)](https://crates.io/crates/{}/{}) [![Docs.rs](https://docs.rs/{}/badge.svg)](https://docs.rs/{}/{})",
+            crate_name, crate_name, version, crate_name, crate_name, version
+        );
+        release_notes = format!("{}\n\n{}", badges, release_notes);
+    }
+
+    // Add explicit crates.io link if provided (overrides auto-detected)
     if let Some(url) = crates_io_url {
         release_notes = format!("{}\n\n{}", url, release_notes);
     }


### PR DESCRIPTION
## Summary

Fixes #34 — No GitHub release was published with badge in Rust CI/CD.

### Root Cause

The `create-github-release.rs` script used a regex pattern with a **look-ahead assertion** (`(?=\n## \[|$)`) that is not supported by Rust's `regex` crate. This caused a panic during the Auto Release job after v0.2.0 was published to crates.io, preventing the GitHub Release from being created.

### Changes

- **Fixed regex**: Replaced the unsupported look-ahead pattern with a two-step approach — find the version header, then find the next section boundary separately
- **Added badges**: Restored crates.io and docs.rs badge generation in GitHub Release notes (matching the template repo)
- **Case study**: Added `docs/case-studies/issue-34/analysis.md` with timeline, root cause analysis, and CI log evidence
- **Test**: Added `experiments/test_changelog_regex.rs` to verify the changelog extraction logic
- **Cargo.lock**: Updated stale version in lock file (was still `0.1.0-pre+beta.2`)

### Cross-Repository

Reported the same bug upstream: link-foundation/rust-ai-driven-development-pipeline-template#29

### CI Log Evidence

```
thread 'main' panicked at scripts/create-github-release.rs:48:35:
regex parse error:
    (?s)## \[0\.2\.0\].*?\n(.*?)(?=\n## \[|$)
                                 ^^^
error: look-around, including look-ahead and look-behind, is not supported
```

## Test Plan

- [x] All existing tests pass (`cargo test --all-features`)
- [x] Regex experiment passes (`rust-script experiments/test_changelog_regex.rs`)
- [x] No look-ahead patterns remain in any scripts
- [ ] CI passes on this PR
- [ ] After merge, Auto Release creates GitHub Release with badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)